### PR TITLE
[12] Integrate Moko Resources to share project resources between platforms

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "android"]
 	path = android
 	url = git@github.com:nimblehq/android-templates.git
-	branch = feature/replace-hilt-with-koin
+	branch = feature/moko-resources

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -52,6 +52,13 @@ object Dependencies {
         const val COMMON_KTX = "com.github.nimblehq:android-common-ktx:${Versions.COMMON_KTX}"
     }
 
+    object Moko {
+        const val RESOURCES_GENERATOR = "dev.icerock.moko:resources-generator:${Versions.MOKO_RESOURCES}"
+        const val RESOURCES = "dev.icerock.moko:resources:${Versions.MOKO_RESOURCES}"
+        const val RESOURCES_COMPOSE = "dev.icerock.moko:resources-compose:${Versions.MOKO_RESOURCES}"
+        const val GRAPHICS = "dev.icerock.moko:graphics:${Versions.MOKO_GRAPHICS}"
+    }
+
     object Test {
         const val COMPOSE_UI_TEST_JUNIT = "androidx.compose.ui:ui-test-junit4"
         const val COROUTINES = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.KOTLIN_COROUTINES}"
@@ -65,6 +72,8 @@ object Dependencies {
         const val MOCKATIVE_PROCESSOR = "io.mockative:mockative-processor:${Versions.MOCKATIVE}"
         const val MOCKK = "io.mockk:mockk:${Versions.MOCKK}"
         const val MOCKK_ANDROID = "io.mockk:mockk-android:${Versions.MOCKK}"
+
+        const val MOKO_RESOURCES_TEST = "dev.icerock.moko:resources-test:${Versions.MOKO_RESOURCES}"
 
         const val ROBOLECTRIC = "org.robolectric:robolectric:${Versions.ROBOLECTRIC}"
 

--- a/buildSrc/src/main/java/Plugins.kt
+++ b/buildSrc/src/main/java/Plugins.kt
@@ -16,5 +16,7 @@ object Plugins {
     const val KOVER = "org.jetbrains.kotlinx.kover"
     const val KSP = "com.google.devtools.ksp"
 
+    const val MOKO = "dev.icerock.mobile.multiplatform-resources"
+
     const val MULTIPLATFORM = "multiplatform"
 }

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -38,6 +38,9 @@ object Versions {
     const val MOCKATIVE = "1.3.0"
     const val MOCKK = "1.13.3"
 
+    const val MOKO_RESOURCES = "0.23.0"
+    const val MOKO_GRAPHICS = "0.9.0"
+
     const val NAPIER = "2.6.1"
 
     const val ROBOLECTRIC = "4.9.1"

--- a/sample/android/src/main/java/co/nimblehq/kmm/template/MainApplication.kt
+++ b/sample/android/src/main/java/co/nimblehq/kmm/template/MainApplication.kt
@@ -1,6 +1,7 @@
 package co.nimblehq.kmm.template
 
 import android.app.Application
+import co.nimblehq.common.extensions.BuildConfig
 import co.nimblehq.kmm.template.di.initKoin
 import co.nimblehq.kmm.template.di.modules.appModule
 import co.nimblehq.kmm.template.di.modules.viewModelModule

--- a/sample/android/src/main/java/co/nimblehq/kmm/template/ui/screens/home/HomeScreen.kt
+++ b/sample/android/src/main/java/co/nimblehq/kmm/template/ui/screens/home/HomeScreen.kt
@@ -11,7 +11,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.nimblehq.kmm.template.R
+import co.nimblehq.kmm.template.Strings
 import co.nimblehq.kmm.template.extensions.collectAsEffect
+import co.nimblehq.kmm.template.getPlatform
+import co.nimblehq.kmm.template.sharedres.SharedRes
 import co.nimblehq.kmm.template.ui.AppDestination
 import co.nimblehq.kmm.template.ui.models.UiModel
 import co.nimblehq.kmm.template.ui.showToast
@@ -32,7 +35,10 @@ fun HomeScreen(
     val uiModels: List<UiModel> by viewModel.uiModels.collectAsStateWithLifecycle()
 
     HomeScreenContent(
-        title = stringResource(id = R.string.app_name),
+        title = Strings(LocalContext.current).get(
+            id = SharedRes.strings.greeting,
+            args = listOf(getPlatform().name)
+        ),
         uiModels = uiModels
     )
 }
@@ -40,7 +46,7 @@ fun HomeScreen(
 @Composable
 private fun HomeScreenContent(
     title: String,
-    uiModels: List<UiModel>
+    uiModels: List<UiModel>,
 ) {
     Column(
         modifier = Modifier.fillMaxSize(),

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -11,6 +11,12 @@ plugins {
     kotlin(Plugins.KOTLIN_SERIALIZATION) version Versions.KOTLIN
 }
 
+buildscript {
+    dependencies {
+        classpath(Dependencies.Moko.RESOURCES_GENERATOR)
+    }
+}
+
 detekt {
     toolVersion = Versions.DETEKT
     config.setFrom("detekt.yml")

--- a/sample/buildSrc/src/main/java/Dependencies.kt
+++ b/sample/buildSrc/src/main/java/Dependencies.kt
@@ -52,6 +52,13 @@ object Dependencies {
         const val COMMON_KTX = "com.github.nimblehq:android-common-ktx:${Versions.COMMON_KTX}"
     }
 
+    object Moko {
+        const val RESOURCES_GENERATOR = "dev.icerock.moko:resources-generator:${Versions.MOKO_RESOURCES}"
+        const val RESOURCES = "dev.icerock.moko:resources:${Versions.MOKO_RESOURCES}"
+        const val RESOURCES_COMPOSE = "dev.icerock.moko:resources-compose:${Versions.MOKO_RESOURCES}"
+        const val GRAPHICS = "dev.icerock.moko:graphics:${Versions.MOKO_GRAPHICS}"
+    }
+
     object Test {
         const val COMPOSE_UI_TEST_JUNIT = "androidx.compose.ui:ui-test-junit4"
         const val COROUTINES = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.KOTLIN_COROUTINES}"
@@ -65,6 +72,8 @@ object Dependencies {
         const val MOCKATIVE_PROCESSOR = "io.mockative:mockative-processor:${Versions.MOCKATIVE}"
         const val MOCKK = "io.mockk:mockk:${Versions.MOCKK}"
         const val MOCKK_ANDROID = "io.mockk:mockk-android:${Versions.MOCKK}"
+
+        const val MOKO_RESOURCES_TEST = "dev.icerock.moko:resources-test:${Versions.MOKO_RESOURCES}"
 
         const val ROBOLECTRIC = "org.robolectric:robolectric:${Versions.ROBOLECTRIC}"
 

--- a/sample/buildSrc/src/main/java/Plugins.kt
+++ b/sample/buildSrc/src/main/java/Plugins.kt
@@ -16,5 +16,7 @@ object Plugins {
     const val KOVER = "org.jetbrains.kotlinx.kover"
     const val KSP = "com.google.devtools.ksp"
 
+    const val MOKO = "dev.icerock.mobile.multiplatform-resources"
+
     const val MULTIPLATFORM = "multiplatform"
 }

--- a/sample/buildSrc/src/main/java/Versions.kt
+++ b/sample/buildSrc/src/main/java/Versions.kt
@@ -38,6 +38,9 @@ object Versions {
     const val MOCKATIVE = "1.3.0"
     const val MOCKK = "1.13.3"
 
+    const val MOKO_RESOURCES = "0.23.0"
+    const val MOKO_GRAPHICS = "0.9.0"
+
     const val NAPIER = "2.6.1"
 
     const val ROBOLECTRIC = "4.9.1"

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -66,7 +66,7 @@ kotlin {
 
                 with(Dependencies.Moko) {
                     api(RESOURCES)
-                    // api(RESOURCES_COMPOSE) FIXME: Cannot build the shared module with this dependency
+                    api(RESOURCES_COMPOSE) FIXME: Cannot build the shared module with this dependency
                 }
             }
         }

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     id(Plugins.KOVER)
     id(Plugins.KSP)
     id(Plugins.BUILD_KONFIG)
+    id(Plugins.MOKO)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +37,8 @@ kotlin {
         podfile = project.file("../ios/Podfile")
         framework {
             baseName = "shared"
+            export(Dependencies.Moko.RESOURCES)
+            export(Dependencies.Moko.GRAPHICS)
         }
 
         xcodeConfigurationToNativeBuildType["Debug Staging"] = NativeBuildType.DEBUG
@@ -60,6 +63,11 @@ kotlin {
                 }
 
                 implementation(Dependencies.Log.NAPIER)
+
+                with(Dependencies.Moko) {
+                    api(RESOURCES)
+                    // api(RESOURCES_COMPOSE) FIXME: Cannot build the shared module with this dependency
+                }
             }
         }
         val commonTest by getting {
@@ -144,4 +152,9 @@ buildkonfig {
             buildKonfigProperties.getProperty("PRODUCTION_BASE_URL")
         )
     }
+}
+
+multiplatformResources {
+    multiplatformResourcesPackage = "co.nimblehq.kmm.template.sharedres"
+    multiplatformResourcesClassName = "SharedRes"
 }

--- a/sample/shared/src/androidMain/kotlin/co/nimblehq/kmm/template/Strings.kt
+++ b/sample/shared/src/androidMain/kotlin/co/nimblehq/kmm/template/Strings.kt
@@ -1,0 +1,20 @@
+package co.nimblehq.kmm.template
+
+import android.content.Context
+import dev.icerock.moko.resources.StringResource
+import dev.icerock.moko.resources.desc.Resource
+import dev.icerock.moko.resources.desc.StringDesc
+import dev.icerock.moko.resources.format
+
+actual class Strings(private val context: Context) {
+    actual fun get(
+        id: StringResource,
+        args: List<Any>,
+    ): String {
+        return if (args.isEmpty()) {
+            StringDesc.Resource(id).toString(context = context)
+        } else {
+            id.format(*args.toTypedArray()).toString(context)
+        }
+    }
+}

--- a/sample/shared/src/commonMain/kotlin/co/nimblehq/kmm/template/Strings.kt
+++ b/sample/shared/src/commonMain/kotlin/co/nimblehq/kmm/template/Strings.kt
@@ -1,0 +1,7 @@
+package co.nimblehq.kmm.template
+
+import dev.icerock.moko.resources.StringResource
+
+expect class Strings {
+    fun get(id: StringResource, args: List<Any> = emptyList()): String
+}

--- a/sample/shared/src/commonMain/resources/MR/base/strings.xml
+++ b/sample/shared/src/commonMain/resources/MR/base/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="greeting">Hello, %s!</string>
+</resources>

--- a/sample/shared/src/iosMain/kotlin/co/nimblehq/kmm/template/Strings.kt
+++ b/sample/shared/src/iosMain/kotlin/co/nimblehq/kmm/template/Strings.kt
@@ -1,0 +1,19 @@
+package co.nimblehq.kmm.template
+
+import dev.icerock.moko.resources.StringResource
+import dev.icerock.moko.resources.desc.Resource
+import dev.icerock.moko.resources.desc.StringDesc
+import dev.icerock.moko.resources.format
+
+actual class Strings {
+    actual fun get(
+        id: StringResource,
+        args: List<Any>,
+    ): String {
+        return if (args.isEmpty()) {
+            StringDesc.Resource(id).localized()
+        } else {
+            id.format(*args.toTypedArray()).localized()
+        }
+    }
+}

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     id(Plugins.KOVER)
     id(Plugins.KSP)
     id(Plugins.BUILD_KONFIG)
+    id(Plugins.MOKO)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +37,8 @@ kotlin {
         podfile = project.file("../ios/Podfile")
         framework {
             baseName = "shared"
+            export(Dependencies.Moko.RESOURCES)
+            export(Dependencies.Moko.GRAPHICS)
         }
 
         xcodeConfigurationToNativeBuildType["Debug Staging"] = NativeBuildType.DEBUG
@@ -60,6 +63,11 @@ kotlin {
                 }
 
                 implementation(Dependencies.Log.NAPIER)
+
+                with(Dependencies.Moko) {
+                    api(RESOURCES)
+                    api(RESOURCES_COMPOSE)
+                }
             }
         }
         val commonTest by getting {
@@ -144,4 +152,9 @@ buildkonfig {
             buildKonfigProperties.getProperty("PRODUCTION_BASE_URL")
         )
     }
+}
+
+multiplatformResources {
+    multiplatformResourcesPackage = "co.nimblehq.kmm.template.sharedres"
+    multiplatformResourcesClassName = "SharedRes"
 }

--- a/shared/src/androidMain/kotlin/co/nimblehq/kmm/template/Strings.kt
+++ b/shared/src/androidMain/kotlin/co/nimblehq/kmm/template/Strings.kt
@@ -1,0 +1,20 @@
+package co.nimblehq.kmm.template
+
+import android.content.Context
+import dev.icerock.moko.resources.StringResource
+import dev.icerock.moko.resources.desc.Resource
+import dev.icerock.moko.resources.desc.StringDesc
+import dev.icerock.moko.resources.format
+
+actual class Strings(private val context: Context) {
+    actual fun get(
+        id: StringResource,
+        args: List<Any>,
+    ): String {
+        return if (args.isEmpty()) {
+            StringDesc.Resource(id).toString(context = context)
+        } else {
+            id.format(*args.toTypedArray()).toString(context)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/kmm/template/Strings.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/kmm/template/Strings.kt
@@ -1,0 +1,7 @@
+package co.nimblehq.kmm.template
+
+import dev.icerock.moko.resources.StringResource
+
+expect class Strings {
+    fun get(id: StringResource, args: List<Any> = emptyList()): String
+}

--- a/shared/src/commonMain/resources/MR/base/strings.xml
+++ b/shared/src/commonMain/resources/MR/base/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="greeting">Hello, %s!</string>
+</resources>

--- a/shared/src/iosMain/kotlin/co/nimblehq/kmm/template/Strings.kt
+++ b/shared/src/iosMain/kotlin/co/nimblehq/kmm/template/Strings.kt
@@ -1,0 +1,19 @@
+package co.nimblehq.kmm.template
+
+import dev.icerock.moko.resources.StringResource
+import dev.icerock.moko.resources.desc.Resource
+import dev.icerock.moko.resources.desc.StringDesc
+import dev.icerock.moko.resources.format
+
+actual class Strings {
+    actual fun get(
+        id: StringResource,
+        args: List<Any>,
+    ): String {
+        return if (args.isEmpty()) {
+            StringDesc.Resource(id).localized()
+        } else {
+            id.format(*args.toTypedArray()).localized()
+        }
+    }
+}


### PR DESCRIPTION
- Close #12 

## What happened 👀

Add [Moko Resources](https://github.com/icerockdev/moko-resources) to the template.

## Insight 📝

* Added Moko Resources according to the instructions on the official GitHub page and with the help of [this video](https://www.youtube.com/watch?v=xtWzpLtCuY0).
* For some reason, the `:shared` module fails to build if we add the dependency `dev.icerock.moko:resources-compose:0.23.0`. This line has been commented out for now until a resolution is found.
* Added `expect` and `actual` classes and methods of `Strings` as a helper to get the strings from Moko resources in both the Android and iOS apps.

## Proof Of Work 📹

### Android
<img src="https://github.com/nimblehq/kmm-templates/assets/8093908/548e48b5-c592-412c-b034-81ae153c27d5" width=200 /> 

### iOS
![image](https://github.com/nimblehq/kmm-templates/assets/8093908/ceead9c4-a537-4f07-95d6-e55615ed35d4)


